### PR TITLE
add validation of file names

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -100,6 +100,10 @@ pub mod gui {
             let mut file_names: Vec<String> = vec![];
             let list_names = browser.borrow();
             log::info!("Processing {} files", list_names.size());
+            if list_names.size() == 0 {
+                log::info!("No files to process");
+                return;
+            }
             for i in 1..=list_names.size() {
                 let line_content = browser.borrow().text(i);
                 match line_content {
@@ -159,7 +163,7 @@ pub mod gui {
     ) {
         load_button.set_callback(move |_| {
             let mut chooser = dialog::FileDialog::new(dialog::FileDialogType::BrowseMultiFile);
-            chooser.set_directory(&".");
+            let _ = chooser.set_directory(&".");
             chooser.set_filter("*.{pdf,xlsx,csv}");
             chooser.set_title("Choose e-trade documents with transactions (PDF and/or XLSX)");
             chooser.show();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,8 +250,8 @@ fn compute_sold_taxation(transactions: &Vec<SoldTransaction>) -> (f32, f32) {
 pub fn format_sold_transactions_to_string() {}
 
 use std::collections::HashSet;
-use std::path::Path;
 use std::ffi::OsStr;
+use std::path::Path;
 
 /* Check:
 if file names have no duplicates
@@ -262,7 +262,7 @@ pub fn validate_file_names(files: &Vec<String>) -> Result<(), String> {
     let mut names_set = HashSet::new();
     let mut spreadsheet_count = 0;
     let mut errors = Vec::<String>::new();
-    
+
     for file_str in files {
         let path = Path::new(&file_str);
         if !path.is_file() {
@@ -279,7 +279,7 @@ pub fn validate_file_names(files: &Vec<String>) -> Result<(), String> {
             // Couldn't test it on windows.
             errors.push(format!("File has no name: {}", file_str));
         }
-        
+
         match path.extension().and_then(OsStr::to_str) {
             Some("xlsx") => spreadsheet_count += 1,
             Some("csv") | Some("pdf") => {},
@@ -289,9 +289,12 @@ pub fn validate_file_names(files: &Vec<String>) -> Result<(), String> {
     }
 
     if spreadsheet_count > 1 {
-        errors.push(format!("Expected a single xlsx spreadsheet, found: {}", spreadsheet_count));
+        errors.push(format!(
+            "Expected a single xlsx spreadsheet, found: {}",
+            spreadsheet_count
+        ));
     }
-    
+
     if errors.len() > 0 {
         return Err(errors.join("\n"));
     }
@@ -315,7 +318,7 @@ pub fn run_taxation(
     String,
 > {
     validate_file_names(&names)?;
-    
+
     let mut parsed_interests_transactions: Vec<(String, f32)> = vec![];
     let mut parsed_div_transactions: Vec<(String, f32, f32)> = vec![];
     let mut parsed_sold_transactions: Vec<(String, String, f32, f32, f32)> = vec![];
@@ -429,7 +432,7 @@ pub fn run_taxation(
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_validate_file_names_invalid_path() {
         let files = vec![
@@ -452,7 +455,10 @@ mod tests {
         ];
 
         let result = validate_file_names(&files);
-        assert_eq!(result.err(), Some(String::from("Expected a single xlsx spreadsheet, found: 2")));
+        assert_eq!(
+            result.err(),
+            Some(String::from("Expected a single xlsx spreadsheet, found: 2"))
+        );
     }
 
     #[test]
@@ -483,7 +489,10 @@ mod tests {
         let files = vec![String::from("LICENCE")];
 
         let result = validate_file_names(&files);
-        assert_eq!(result.err(), Some(String::from("File has no extension: LICENCE")));
+        assert_eq!(
+            result.err(),
+            Some(String::from("File has no extension: LICENCE"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Preliminary validation of input files by their names.
Included a line to silence clippy.
Included check if execute was called without any files added.