### PR TITLE
Add anonymizer tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 target
+
+# Local test PDF fixtures (not committed to repo; place plain PDFs here for offline tests)
+anonymizer_data/*.pdf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,7 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
+ "flate2",
  "fltk",
  "holidays",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ exclude = [
 [[bin]]
 name = "etradeTaxReturnHelper"
 path = "src/main.rs"
+[[bin]]
+name = "etradeAnonymizer"
+path = "src/anonymizer/anonymizer.rs"
 
 [[bin]]
 name = "gen_exchange_rates"
@@ -49,5 +52,4 @@ polars = "0.36.2"
 csv = "1.3.0"
 serde_json = { version = "=1.0.133", optional = true }
 holidays = { version = "0.1.0", default-features = false, features = ["PL"] }
-
-
+flate2 = "1.1.5"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2022-2025 RustInFinance
+SPDX-FileCopyrightText: 2022-2026 RustInFinance
 SPDX-License-Identifier: BSD-3-Clause
 -->
 

--- a/src/anonymizer/README.md
+++ b/src/anonymizer/README.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-FileCopyrightText: 2025 RustInFinance
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# etradeAnonymizer
+
+Minimal Rust tool for anonymizing E*TRADE / Morgan Stanley PDF statements by replacing personally identifiable information while preserving calculation-relevant data.
+
+## Usage
+
+Anonymize a PDF (creates `anonymous_statement.pdf` by default):
+```
+cargo run --bin etradeAnonymizer -- anonymize statement.pdf
+```
+
+Specify output file:
+```
+cargo run --bin etradeAnonymizer -- anonymize input.pdf output.pdf
+```
+
+List all text tokens (for debugging):
+```
+cargo run --bin etradeAnonymizer -- list statement.pdf
+```
+
+## Build & Test
+```
+cargo build --release --bin etradeAnonymizer
+# Tests live in the library target (there are no tests in the binary itself):
+cargo test --lib anonymizer
+```
+
+Resulting binary: `target/release/etradeAnonymizer`.
+
+## Anonymization Strategy
+
+The tool processes PDF FlateDecode streams and applies smart text replacement:
+
+1. **Preserve calculation-relevant strings**:
+   - Strings containing `CLIENT STATEMENT` or `For the Period`
+   - Everything between `CASH FLOW ACTIVITY BY DATE` and `NET CREDITS/(DEBITS)` (inclusive)
+
+2. **Replace all other text**:
+   - The current implementation replaces non-preserved strings with stable numeric tokens (`0`, `1`, `2`, ...).
+   - This removes PII while keeping structure and relative token identity for verification and testing.
+
+## Technical Specification (YAGNI Scope)
+
+This tool follows the **YAGNI (You Ain't Gonna Need It)** principle, focusing only on the subset of the PDF standard actually used in the target documents.
+
+### Supported Features
+- **PDF Standard:** Basic PDF 1.3 structure.
+- **Streams:** `stream` objects compressed with `/FlateDecode` or raw (uncompressed) with an explicit `/Length`.
+- **Text Blocks:** Data contained between `BT` (Begin Text) and `ET` (End Text) operators.
+- **Text Operators:** Extraction from `(...) Tj` and `[...] TJ` arrays.
+- **Unescaping:** Support for standard PDF escape sequences: `\n`, `\r`, `\t`, `\b`, `\f`, `\(`, `\)`, `\\`, and octal sequences `\ddd`.
+- **Encoding:** Text treated as ASCII/Latin-1 (internally handled as UTF-8).
+
+
+## Design Notes
+- **Regex-based Discovery:** The tool uses optimized regular expressions to scan the PDF binary for stream object headers. This allows for fast location of data without full PDF structure parsing.
+- Strict PDF header (`%PDF-1.3`) enforcement; files with any other header are rejected.
+- FlateDecode and uncompressed streams with an explicit `/Length` are processed.
+- Replacement recompresses; if no level fits original size, original compressed stream is kept.
+
+## Testing & Development
+
+### Running Tests
+Most unit tests run automatically with `cargo test`. Integration tests that require real PDF files are marked `#[ignore]` and will not run on CI.
+
+To run the integration tests locally:
+1. Place the plain PDF fixtures (`sample_statement.pdf`, `sample_statement_anonymized.pdf`) in the `anonymizer_data/` directory (git-ignored).
+2. Run:
+   ```bash
+   cargo test --lib anonymizer -- --ignored
+   # or without GUI dependencies:
+   cargo test --lib anonymizer --no-default-features -- --ignored
+   ```
+
+### Known Limitations (YAGNI Scope)
+- **Indirect Length Objects:** The scanner currently only supports streams with an explicit numeric `/Length` in the dictionary. It will skip streams where the length is a reference (e.g., `/Length 12 0 R`).
+- **Standard PDF Filters:** Only `/FlateDecode` is supported for text extraction. Image streams (e.g., `/DCTDecode`) and font files are intentionally ignored as they do not contain PII in target documents.
+
+### Why Padding? (Architecture Note)
+This tool avoids full PDF parsing and rebuilding. Instead, it modifies streams **in-place**.
+- PDF files rely on a Cross-Reference (XREF) table that stores the byte offset of every object.
+- If we changed the length of a stream object, all subsequent object offsets would shift, invalidating the XREF table.
+- To avoid rebuilding the XREF table, we ensure the modified stream is **exactly the same length** as the original.
+- If the new compressed data is smaller, we **pad** the remainder with null bytes (`0x00`).
+- If the new compressed data is larger than the original, we fall back to keeping the original stream to avoid file corruption.
+
+### Exact PDF object pattern searched
+The tool searches for PDF objects that exactly match the following pattern:
+
+```
+<number> <number> obj
+<<
+/Length <number>
+/Filter [/FlateDecode]
+>>
+stream
+<exactly Length bytes>
+endstream
+endobj
+```
+
+Note about `list` showing "0 tokens": the command always prints a stream dump header, but the token extractor only reports tokens when it finds PDF text-showing operators (e.g. `Tj`, `TJ`, `\'`, `"`). Non-text streams (images, fonts, etc.) will naturally show "0 tokens".
+
+## License
+See `BSD-3-Clause` in `LICENSES/` directory.
+
+## Disclaimer
+
+Please note: this tool attempts to detect and replace everything except the information required for calculation by analyzing tokens in PDF streams that are strictly defined, but there is no guarantee that all PII will be detected or removed. You must manually review the resulting file before sharing it.

--- a/src/anonymizer/anonymizer.rs
+++ b/src/anonymizer/anonymizer.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! etradeAnonymizer - PDF anonymization tool for E*TRADE / Morgan Stanley statements.
+//!
+//! This tool provides two subcommands:
+//! - `list`: List all text tokens from FlateDecode streams in a PDF
+//! - `anonymize`: Anonymize PDF by replacing all PII except calculation-relevant data
+//!
+//! The tool operates on tightly structured PDF FlateDecode streams and preserves
+//! the original file structure by performing in-place replacements with exact-size matching.
+
+// Submodules are exported by `src/anonymizer/mod.rs` via the library crate.
+// Since this file is a binary entry point, reference them via `etradeTaxReturnHelper::anonymizer::...`.
+
+use clap::{Parser, Subcommand};
+use etradeTaxReturnHelper::anonymizer;
+use std::error::Error;
+use std::path::PathBuf;
+
+/// Tool for anonymizing PDF files by replacing specific strings in FlateDecode streams
+#[derive(Parser)]
+#[command(name = "etradeAnonymizer")]
+#[command(version, about, long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// List all text tokens from FlateDecode streams in the PDF
+    List {
+        /// Path to the input PDF file
+        input_file: PathBuf,
+    },
+    /// Anonymize PDF by replacing all text except calculation-relevant data
+    Anonymize {
+        /// Path to the input PDF file
+        input_file: PathBuf,
+        /// Path to the output PDF file (optional, defaults to anonymous_<input>.pdf)
+        output_file: Option<PathBuf>,
+    },
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Default to `warn` level; RUST_LOG env var overrides this if set.
+    simple_logger::SimpleLogger::new()
+        .with_level(log::LevelFilter::Warn)
+        .env()
+        .init()
+        .unwrap();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::List { input_file } => anonymizer::list::list_texts(&input_file),
+        Commands::Anonymize {
+            input_file,
+            output_file,
+        } => {
+            let output =
+                output_file.unwrap_or_else(|| anonymizer::path::anonymous_output_path(&input_file));
+            anonymizer::replace::replace_pii_smart(&input_file, &output)
+        }
+    }
+}

--- a/src/anonymizer/list.rs
+++ b/src/anonymizer/list.rs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Text listing module for anonymizer.
+//!
+//! This module provides functionality to extract and list all text tokens from
+//! FlateDecode and uncompressed streams (with an explicit /Length) in a PDF. Each
+//! token is printed with a global index, useful for understanding the structure and
+//! content of the PDF before anonymization.
+
+use super::pdf::{extract_texts_from_stream, read_pdf, stream_scanner};
+use log::warn;
+use std::error::Error;
+use std::path::Path;
+
+/// List all text tokens from FlateDecode and uncompressed streams in the PDF at `input_path`.
+///
+/// Prints each extracted token with a global index to stdout.
+/// Logs warnings for streams that fail to decompress or have invalid markers.
+///
+/// # Arguments
+/// * `input_path` - Path to the input PDF file.
+///
+/// # Returns
+/// `Ok(())` on success, or an error if the PDF cannot be read.
+pub fn list_texts(input_path: &Path) -> Result<(), Box<dyn Error>> {
+    let pdf_data = read_pdf(input_path)?;
+
+    let mut global_text_id = 0;
+    for (stream_id, stream) in stream_scanner(&pdf_data).enumerate() {
+        if !stream.valid_end_marker {
+            warn!(
+                "Skipping stream due to end-marker mismatch for object at {}",
+                stream.object_start
+            );
+            continue;
+        }
+
+        let extraction = extract_texts_from_stream(stream.compressed, stream.is_compressed);
+
+        match extraction {
+            Ok(extracted_texts) => {
+                println!("---------------------------------------------------------------");
+                println!("STREAM #{} ({} tokens)", stream_id, extracted_texts.len());
+                println!("---------------------------------------------------------------");
+                for (txt, _start, _end) in extracted_texts.iter() {
+                    // Sanitize token for console: escape non-printable bytes to avoid
+                    // terminal mojibake when streams contain binary data.
+                    let safe: String = txt.chars().flat_map(|c| c.escape_default()).collect();
+                    println!("  [{}] {}", global_text_id, safe);
+                    global_text_id += 1;
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to extract texts from stream at {}: {}",
+                    stream.object_start, e
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/anonymizer/mod.rs
+++ b/src/anonymizer/mod.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Anonymizer module re-exports.
+
+pub mod list;
+pub mod path;
+pub mod pdf;
+pub mod replace;

--- a/src/anonymizer/path.rs
+++ b/src/anonymizer/path.rs
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! Path utility module for anonymizer.
+//!
+//! Provides helper functions for generating anonymized output file paths
+//! by prefixing filenames with `anonymous_` while preserving directory structure.
+
+use std::path::PathBuf;
+
+/// Build an output path by prefixing the input filename with `anonymous_`.
+///
+/// Preserves the parent directory if present and returns a `PathBuf`.
+///
+/// # Examples
+/// ```ignore
+/// use std::path::Path;
+/// let input = Path::new("data/statement.pdf");
+/// let output = anonymous_output_path(input);
+/// assert_eq!(output, Path::new("data/anonymous_statement.pdf"));
+/// ```
+pub fn anonymous_output_path(input_path: &std::path::Path) -> PathBuf {
+    let file_name = input_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| input_path.to_string_lossy().into_owned());
+
+    if let Some(parent) = input_path.parent() {
+        let mut pb = PathBuf::from(parent);
+        pb.push(format!("anonymous_{}", file_name));
+        pb
+    } else {
+        PathBuf::from(format!("anonymous_{}", file_name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_anonymous_output_path_no_parent() {
+        let in_path = std::path::Path::new("statement.pdf");
+        let out = anonymous_output_path(in_path);
+        assert_eq!(out, std::path::PathBuf::from("anonymous_statement.pdf"));
+    }
+
+    #[test]
+    fn test_anonymous_output_path_with_parent() {
+        let in_path = std::path::Path::new("some/dir/statement.pdf");
+        let out = anonymous_output_path(in_path);
+        assert_eq!(
+            out,
+            std::path::PathBuf::from("some/dir/anonymous_statement.pdf")
+        );
+    }
+
+    #[test]
+    fn test_anonymous_output_path_unicode_filename() {
+        let in_path = std::path::Path::new("résumé.pdf");
+        let out = anonymous_output_path(in_path);
+        assert_eq!(out, std::path::PathBuf::from("anonymous_résumé.pdf"));
+    }
+}

--- a/src/anonymizer/pdf.rs
+++ b/src/anonymizer/pdf.rs
@@ -1,0 +1,1115 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! PDF parsing utilities: header validation, stream extraction, text token parsing.
+//! This module is intentionally strict and only supports a narrow subset of PDF
+//! objects used by the target documents: FlateDecode streams with explicit /Length.
+
+use flate2::read::ZlibDecoder;
+use log::{error, warn};
+use regex::bytes::Regex;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+
+// Centralized constants and helpers for PDF parsing to reduce duplication between list/replace.
+/// Expected PDF header (strictly enforced).
+pub(crate) const PDF_HEADER: &[u8] = b"%PDF-1.3";
+/// Regex matching any stream object with an explicit `/Length`.
+/// Uses (?s) DOTALL so the dictionary may span newlines; `[^>]` keeps a match
+/// within a single dictionary (no nested `>`), matching the narrow object shapes
+/// these documents use. The scanner then classifies each match by inspecting the
+/// dictionary text only (never the binary payload), in this order:
+/// - contains `/Length1` -> embedded font program (FontFile/FontFile2), skipped
+///   regardless of compression: binary font data has no PDF text tokens and must
+///   never be modified,
+/// - otherwise contains `/FlateDecode` -> compressed (zlib-decoded and scanned),
+/// - otherwise contains `/Filter` -> unsupported filter (e.g. `/DCTDecode`
+///   image), skipped,
+/// - otherwise -> genuine uncompressed content stream, scanned verbatim.
+pub(crate) const OBJ_STREAM_RE: &str =
+    r"(?s)\d+\s+\d+\s+obj\s*<<[^>]*?/Length\s+(\d+)[^>]*?>>\s*stream\r?\n";
+
+/// Read entire PDF file and validate strict header.
+pub fn read_pdf(path: &std::path::Path) -> Result<Vec<u8>, Box<dyn Error>> {
+    let mut file = File::open(path)?;
+    let mut pdf_data = Vec::new();
+    file.read_to_end(&mut pdf_data)?;
+    if pdf_data.len() < PDF_HEADER.len() || &pdf_data[0..PDF_HEADER.len()] != PDF_HEADER {
+        error!(
+            "Unsupported PDF version or invalid PDF header at '{}'.",
+            path.display()
+        );
+        return Err("Invalid PDF header".into());
+    }
+    Ok(pdf_data)
+}
+
+/// Lightweight representation of a stream slice inside a PDF (compressed or uncompressed).
+pub struct StreamData<'a> {
+    pub object_start: usize,
+    pub data_start: usize,
+    pub compressed: &'a [u8],
+    pub valid_end_marker: bool,
+    pub is_compressed: bool,
+}
+
+/// Iterator over stream objects, avoiding allocating a full Vec upfront.
+pub struct StreamScanner<'a> {
+    re: Regex,
+    data: &'a [u8],
+    search_from: usize,
+}
+
+/// Create a new streaming iterator over PDF stream objects (compressed and uncompressed).
+pub fn stream_scanner<'a>(pdf_data: &'a [u8]) -> StreamScanner<'a> {
+    StreamScanner {
+        re: Regex::new(OBJ_STREAM_RE).unwrap(),
+        data: pdf_data,
+        search_from: 0,
+    }
+}
+
+/// True if the byte slice `haystack` contains the contiguous subslice `needle`.
+fn bytes_contain(haystack: &[u8], needle: &[u8]) -> bool {
+    needle.len() <= haystack.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+impl<'a> Iterator for StreamScanner<'a> {
+    type Item = StreamData<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.search_from < self.data.len() {
+            let caps = match self.re.captures_at(self.data, self.search_from) {
+                Some(c) => c,
+                None => {
+                    self.search_from = self.data.len();
+                    return None;
+                }
+            };
+
+            let whole = caps.get(0)?;
+            self.search_from = whole.end();
+
+            // Classify by inspecting only the matched object header/dictionary
+            // (never the binary payload, which begins after `stream`).
+            let dict = whole.as_bytes();
+            let is_compressed = if bytes_contain(dict, b"/Length1") {
+                // Embedded font program (FontFile/FontFile2): binary font data
+                // with no PDF text tokens. Checked first so that even a
+                // Flate-compressed font is skipped, never scanned/modified.
+                continue;
+            } else if bytes_contain(dict, b"/FlateDecode") {
+                true
+            } else if bytes_contain(dict, b"/Filter") {
+                // Unsupported filter (e.g. /DCTDecode image): don't decode/scan.
+                continue;
+            } else {
+                false
+            };
+
+            if let Some((data, data_start, valid)) = extract_stream_bytes(self.data, &caps) {
+                return Some(StreamData {
+                    object_start: whole.start(),
+                    data_start,
+                    compressed: data,
+                    valid_end_marker: valid,
+                    is_compressed,
+                });
+            } else {
+                continue; // skip invalid capture
+            }
+        }
+        None
+    }
+}
+
+/// Given a capture for a stream object, validate the end marker and return the raw stream bytes plus a validity flag.
+pub(crate) fn extract_stream_bytes<'a>(
+    pdf_data: &'a [u8],
+    caps: &regex::bytes::Captures<'a>,
+) -> Option<(&'a [u8], usize, bool)> {
+    // Strict project rule: expected end marker is fixed here
+    const EXPECTED_END: &[u8] = b"\nendstream\nendobj";
+    // Validate capture groups
+    let whole = match caps.get(0) {
+        Some(m) => m,
+        None => {
+            error!("PDF object capture missing whole-match");
+            return None;
+        }
+    };
+    let length_bytes = match caps.get(1) {
+        Some(m) => m.as_bytes(),
+        None => {
+            error!(
+                "PDF object capture missing /Length group at object starting {}",
+                whole.start()
+            );
+            return None;
+        }
+    };
+
+    // Parse length strictly; if it fails, we consider this object invalid
+    let length = match std::str::from_utf8(length_bytes)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+    {
+        Some(v) => v,
+        None => {
+            error!(
+                "Invalid /Length value '{}' in object starting at {}",
+                String::from_utf8_lossy(length_bytes),
+                whole.start()
+            );
+            return None;
+        }
+    };
+
+    let data_start = whole.end();
+    let stream_end = match data_start.checked_add(length) {
+        Some(v) => v,
+        None => {
+            error!(
+                "Stream end overflow for object at {} (length={})",
+                data_start, length
+            );
+            return None;
+        }
+    };
+
+    // strict bounds checks: must be entirely within pdf_data
+    if stream_end > pdf_data.len() {
+        error!(
+            "Stream end out of bounds for object starting at {}: stream_end={} pdf_len={}",
+            data_start,
+            stream_end,
+            pdf_data.len()
+        );
+        return None;
+    }
+    if stream_end + EXPECTED_END.len() > pdf_data.len() {
+        error!(
+            "End marker out of bounds after stream_end {} for object starting at {} (pdf_len={})",
+            stream_end,
+            data_start,
+            pdf_data.len()
+        );
+        return None;
+    }
+
+    // Validate exact end marker (requirements are strict)
+    let debug_slice = &pdf_data[stream_end..stream_end + EXPECTED_END.len()];
+    if debug_slice != EXPECTED_END {
+        warn!(
+            "End marker mismatch for object starting at {}: found {:?}, expected {:?}",
+            data_start, debug_slice, EXPECTED_END
+        );
+        // Return decompressed candidate but indicate end marker mismatch for caller decision
+        return Some((&pdf_data[data_start..stream_end], data_start, false));
+    }
+
+    Some((&pdf_data[data_start..stream_end], data_start, true))
+}
+
+/// Extracted text token: the decoded string plus its start/end byte offsets
+/// within the decompressed stream.
+pub type TextToken = (String, usize, usize);
+
+/// Extract texts with positions from a compressed or uncompressed stream.
+pub fn extract_texts_from_stream(
+    stream_data: &[u8],
+    is_compressed: bool,
+) -> Result<Vec<TextToken>, Box<dyn Error>> {
+    if is_compressed {
+        let mut decoder = ZlibDecoder::new(stream_data);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed)?;
+        Ok(scan_decompressed_text(&decompressed))
+    } else {
+        Ok(scan_decompressed_text(stream_data))
+    }
+}
+
+/// Extract text tokens (with positions) from an already-decompressed content stream.
+///
+/// Use this when the caller has already decompressed the stream to avoid a second
+/// decompression pass.
+pub fn extract_texts_from_decompressed(decompressed: &[u8]) -> Vec<TextToken> {
+    scan_decompressed_text(decompressed)
+}
+
+/// association of text literal bytes and their positions in the decompressed buffer.
+fn scan_decompressed_text(decompressed: &[u8]) -> Vec<(String, usize, usize)> {
+    // Linear scanner to find parenthesized literal strings reliably
+    // and associate them with text operators. This avoids brittle regexes
+    // and correctly handles escapes, octal sequences and nested parentheses.
+    fn skip_whitespace(buf: &[u8], mut idx: usize) -> usize {
+        while idx < buf.len() {
+            match buf[idx] {
+                b' ' | b'\t' | b'\n' | b'\r' | 0x0C => idx += 1,
+                _ => break,
+            }
+        }
+        idx
+    }
+
+    fn parse_literal(buf: &[u8], open_idx: usize) -> Option<(usize, usize)> {
+        // open_idx points to '('
+        let mut i = open_idx + 1;
+        let mut depth: i32 = 1;
+        while i < buf.len() {
+            match buf[i] {
+                b'\\' => {
+                    // escape: skip next byte if present (octal handled by unescape)
+                    i += 1;
+                    if i < buf.len() {
+                        // skip the escaped character
+                        i += 1;
+                    }
+                }
+                b'(' => {
+                    depth += 1;
+                    i += 1;
+                }
+                b')' => {
+                    depth -= 1;
+                    i += 1;
+                    if depth == 0 {
+                        // return indexes of inner content (exclude parentheses)
+                        return Some((open_idx + 1, i - 1));
+                    }
+                }
+                _ => i += 1,
+            }
+        }
+        None
+    }
+
+    let mut extracted: Vec<(String, usize, usize)> = Vec::new();
+    // Tokens found since the most recent `BT`. They are committed to `extracted`
+    // only when a matching `ET` closes the text object. A stray `BT` that never
+    // closes (typical when non-content binary slips through) leaves its pending
+    // tokens uncommitted, so we never rewrite coincidental byte patterns.
+    let mut pending: Vec<(String, usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    let mut in_text_object = false;
+
+    while i < decompressed.len() {
+        // Look for BT/ET operators to track text object state
+        if i + 1 < decompressed.len() {
+            if &decompressed[i..i + 2] == b"BT" {
+                in_text_object = true;
+                i += 2;
+                continue;
+            } else if &decompressed[i..i + 2] == b"ET" {
+                in_text_object = false;
+                // Commit only fully-closed text objects.
+                extracted.append(&mut pending);
+                i += 2;
+                continue;
+            }
+        }
+
+        match decompressed[i] {
+            b'(' if in_text_object => {
+                if let Some((s, e)) = parse_literal(decompressed, i) {
+                    // after the closing paren at index e+1, check for text operators
+                    let after = skip_whitespace(decompressed, e + 1);
+                    let mut is_text = false;
+                    if after < decompressed.len() {
+                        let op1 = decompressed[after];
+                        if op1 == b'\'' || op1 == b'"' {
+                            is_text = true;
+                        } else if after + 1 < decompressed.len() {
+                            let op2 = &decompressed[after..after + 2];
+                            if op2 == b"Tj" || op2 == b"TJ" {
+                                is_text = true;
+                            }
+                        }
+                    }
+
+                    if is_text {
+                        let raw = &decompressed[s..e];
+                        let unescaped = unescape_pdf_string(raw);
+                        pending.push((String::from_utf8_lossy(&unescaped).to_string(), s, e));
+                    }
+                    i = e + 1; // continue after closing paren
+                } else {
+                    break; // malformed string — stop scanning
+                }
+            }
+            b'[' if in_text_object => {
+                // parse array until matching ']', collecting inner literal items
+                let mut arr_i = i + 1;
+                let mut found_end = false;
+                let mut inner_literals: Vec<(usize, usize)> = Vec::new();
+                while arr_i < decompressed.len() {
+                    match decompressed[arr_i] {
+                        b'(' => {
+                            if let Some((s, e)) = parse_literal(decompressed, arr_i) {
+                                inner_literals.push((s, e));
+                                arr_i = e + 1;
+                            } else {
+                                break; // malformed
+                            }
+                        }
+                        b']' => {
+                            // check for TJ operator after the array
+                            let after = skip_whitespace(decompressed, arr_i + 1);
+                            if after + 1 < decompressed.len()
+                                && &decompressed[after..after + 2] == b"TJ"
+                            {
+                                for (s, e) in inner_literals.iter() {
+                                    let raw = &decompressed[*s..*e];
+                                    let unescaped = unescape_pdf_string(raw);
+                                    pending.push((
+                                        String::from_utf8_lossy(&unescaped).to_string(),
+                                        *s,
+                                        *e,
+                                    ));
+                                }
+                            }
+                            i = arr_i;
+                            found_end = true;
+                            break;
+                        }
+                        b'\\' => {
+                            // skip escaped char inside array (not inside literal)
+                            arr_i += 1;
+                            if arr_i < decompressed.len() {
+                                arr_i += 1;
+                            }
+                        }
+                        _ => arr_i += 1,
+                    }
+                }
+                if !found_end {
+                    break; // malformed array — stop scanning to avoid infinite loop
+                }
+            }
+            _ => i += 1,
+        }
+    }
+
+    // sort and dedup by start index
+    extracted.sort_by_key(|t| t.1);
+    extracted.dedup_by(|a, b| a.1 == b.1);
+    extracted
+}
+
+/// Unescape PDF string literal escape sequences per PDF 1.3 spec (Table 3.2).
+/// Handles: \n \r \t \b \f \( \) \\ and \ddd (octal, 1-3 digits).
+/// Per spec: "If the character following the backslash is not one of those shown
+/// in the table, the backslash is ignored."
+fn unescape_pdf_string(data: &[u8]) -> Vec<u8> {
+    let mut result = Vec::with_capacity(data.len());
+    let mut i = 0;
+
+    while i < data.len() {
+        if data[i] == b'\\' && i + 1 < data.len() {
+            let (output, bytes_consumed) = handle_pdf_escape(&data[i + 1..]);
+            if let Some(byte) = output {
+                result.push(byte);
+            }
+            i += bytes_consumed;
+        } else {
+            result.push(data[i]);
+            i += 1;
+        }
+    }
+    result
+}
+
+/// Handle a single PDF escape sequence starting after the backslash.
+/// Returns (output byte if any, number of bytes to advance including the backslash).
+fn handle_pdf_escape(data: &[u8]) -> (Option<u8>, usize) {
+    if data.is_empty() {
+        return (None, 1); // Lone backslash at end
+    }
+
+    match data[0] {
+        b'n' => (Some(b'\n'), 2),
+        b'r' => (Some(b'\r'), 2),
+        b't' => (Some(b'\t'), 2),
+        b'b' => (Some(b'\x08'), 2), // backspace
+        b'f' => (Some(b'\x0C'), 2), // form feed
+        b'(' => (Some(b'('), 2),
+        b')' => (Some(b')'), 2),
+        b'\\' => (Some(b'\\'), 2),
+        b'0'..=b'7' => parse_pdf_octal_escape(data),
+        // Per spec: ignore backslash for unrecognized escapes
+        _ => (Some(data[0]), 2),
+    }
+}
+
+/// Parse octal escape sequence \ddd (1-3 octal digits).
+/// Returns (parsed byte, bytes consumed including backslash).
+fn parse_pdf_octal_escape(data: &[u8]) -> (Option<u8>, usize) {
+    let mut end = 0;
+    // Consume up to 3 octal digits
+    while end < data.len() && end < 3 && data[end].is_ascii_digit() && data[end] <= b'7' {
+        end += 1;
+    }
+
+    if let Ok(octal_str) = std::str::from_utf8(&data[..end]) {
+        if let Ok(value) = u8::from_str_radix(octal_str, 8) {
+            return (Some(value), end + 1); // +1 for the backslash
+        }
+    }
+
+    // Fallback: ignore backslash if parsing fails
+    (Some(data[0]), 2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unescape_simple_escapes() {
+        // Test all simple escape sequences
+        assert_eq!(unescape_pdf_string(br"\n"), b"\n");
+        assert_eq!(unescape_pdf_string(br"\r"), b"\r");
+        assert_eq!(unescape_pdf_string(br"\t"), b"\t");
+        assert_eq!(unescape_pdf_string(br"\b"), b"\x08"); // backspace
+        assert_eq!(unescape_pdf_string(br"\f"), b"\x0C"); // form feed
+        assert_eq!(unescape_pdf_string(br"\("), b"(");
+        assert_eq!(unescape_pdf_string(br"\)"), b")");
+        assert_eq!(unescape_pdf_string(br"\\"), b"\\");
+    }
+
+    #[test]
+    fn test_unescape_octal_sequences() {
+        // Single digit octal
+        assert_eq!(unescape_pdf_string(br"\0"), b"\x00");
+        assert_eq!(unescape_pdf_string(br"\7"), b"\x07");
+
+        // Two digit octal
+        assert_eq!(unescape_pdf_string(br"\53"), b"+"); // \053 = 43 decimal = '+'
+
+        // Three digit octal
+        assert_eq!(unescape_pdf_string(br"\053"), b"+");
+        assert_eq!(unescape_pdf_string(br"\245"), b"\xA5"); // 165 decimal
+        assert_eq!(unescape_pdf_string(br"\307"), b"\xC7"); // 199 decimal
+
+        // Octal followed by non-digit (from PDF spec example)
+        assert_eq!(unescape_pdf_string(br"\0053"), b"\x053"); // \005 + '3'
+    }
+
+    #[test]
+    fn test_unescape_real_world_case() {
+        // The actual case from the PDF that was failing
+        assert_eq!(
+            unescape_pdf_string(br"NET CREDITS/\(DEBITS\)"),
+            b"NET CREDITS/(DEBITS)"
+        );
+
+        // Dollar amount with parentheses
+        assert_eq!(unescape_pdf_string(br"\(6,085.80\)"), b"(6,085.80)");
+
+        // Date range
+        assert_eq!(
+            unescape_pdf_string(br"\(9/1/25-9/30/25\)"),
+            b"(9/1/25-9/30/25)"
+        );
+    }
+
+    #[test]
+    fn test_unescape_unrecognized_escape() {
+        // Per spec: "If the character following the backslash is not one of those
+        // shown in the table, the backslash is ignored."
+        assert_eq!(unescape_pdf_string(br"\x"), b"x");
+        assert_eq!(unescape_pdf_string(br"\q"), b"q");
+        assert_eq!(unescape_pdf_string(br"\Z"), b"Z");
+    }
+
+    #[test]
+    fn test_unescape_mixed_content() {
+        // Mix of regular text, escapes, and parentheses
+        assert_eq!(
+            unescape_pdf_string(br"Hello\nWorld\t\(test\)"),
+            b"Hello\nWorld\t(test)"
+        );
+
+        // \\ becomes \, then 053 is literal text (not preceded by backslash after unescape)
+        // Then \245 becomes byte 0xA5
+        assert_eq!(
+            unescape_pdf_string(br"Price: \(\\053\245\)"),
+            b"Price: (\\053\xA5)"
+        );
+    }
+
+    #[test]
+    fn test_unescape_edge_cases() {
+        // Empty string
+        assert_eq!(unescape_pdf_string(b""), b"");
+
+        // No escapes
+        assert_eq!(unescape_pdf_string(b"plain text"), b"plain text");
+
+        // Backslash at end (no following character)
+        assert_eq!(unescape_pdf_string(b"text\\"), b"text\\");
+    }
+
+    #[test]
+    fn test_scan_array_operator_boundaries() {
+        // Simulation: [ (text) ] TJ
+        // Ensures the parser stops exactly at ']' and doesn't skip the next byte.
+        let buf = b"BT [(text)] TJ ET";
+        let extracted = scan_decompressed_text(buf);
+
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0].0, "text");
+    }
+
+    #[test]
+    fn test_nested_parentheses() {
+        // PDF spec allows nested parens if balanced: (Text (inner) more)
+        let buf = b"BT (Outer (inner) text) Tj ET";
+        let extracted = scan_decompressed_text(buf);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0].0, "Outer (inner) text");
+    }
+
+    #[test]
+    fn test_binary_junk_resilience() {
+        // Stream containing binary junk that might look like operators
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"BT (Valid) Tj ");
+        buf.push(0x01);
+        buf.push(0x28); // binary '('
+        buf.extend_from_slice(b"JUNK");
+        buf.push(0x29); // binary ')'
+        buf.extend_from_slice(b" ET");
+
+        let extracted = scan_decompressed_text(&buf);
+        // Should find "Valid" and the junk string, but not crash
+        assert!(extracted.iter().any(|(s, _, _)| s == "Valid"));
+        assert!(!extracted.is_empty());
+    }
+
+    #[test]
+    fn test_array_operator_at_et_boundary() {
+        // Test: [(text)]TJ ET
+        // This checks if the parser correctly handles the end of the text block immediately after an array.
+        let buf = b"BT [(text)]TJ ET";
+        let extracted = scan_decompressed_text(buf);
+        assert_eq!(extracted.len(), 1);
+        assert_eq!(extracted[0].0, "text");
+    }
+
+    #[test]
+    fn test_empty_and_max_length_literals() {
+        // Test edge cases for literal lengths
+        let buf = b"BT () Tj (A) Tj (BC) Tj ET";
+        let extracted = scan_decompressed_text(buf);
+        assert_eq!(extracted.len(), 3);
+        assert_eq!(extracted[0].0, "");
+        assert_eq!(extracted[1].0, "A");
+        assert_eq!(extracted[2].0, "BC");
+    }
+
+    // --- Synthetic stream_scanner classification tests ---
+    // These build tiny in-memory PDF snippets (no real fixtures) to exercise how
+    // stream_scanner distinguishes FlateDecode, plain uncompressed, and non-Flate
+    // filtered (e.g. /DCTDecode image) streams.
+
+    /// Zlib-compress `data` the same way real FlateDecode streams are stored.
+    fn flate_compress(data: &[u8]) -> Vec<u8> {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    /// Wrap raw stream bytes in a minimal `N 0 obj << /Length L{extra} >> stream ... endstream endobj`.
+    /// `extra` holds any additional dictionary entries (e.g. ` /Filter [/FlateDecode]`).
+    fn build_stream_object(obj_num: u32, extra_dict: &str, body: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(
+            format!(
+                "{} 0 obj\n<< /Length {}{} >>\nstream\n",
+                obj_num,
+                body.len(),
+                extra_dict
+            )
+            .as_bytes(),
+        );
+        buf.extend_from_slice(body);
+        buf.extend_from_slice(b"\nendstream\nendobj\n");
+        buf
+    }
+
+    #[test]
+    fn test_scanner_classifies_flate_stream_as_compressed() {
+        let compressed = flate_compress(b"BT (SECRET) Tj ET");
+        let pdf = build_stream_object(1, " /Filter [/FlateDecode]", &compressed);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert_eq!(streams.len(), 1);
+        assert!(streams[0].is_compressed);
+        assert!(streams[0].valid_end_marker);
+
+        let texts =
+            extract_texts_from_stream(streams[0].compressed, streams[0].is_compressed).unwrap();
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].0, "SECRET");
+    }
+
+    #[test]
+    fn test_scanner_classifies_plain_length_stream_as_uncompressed() {
+        // A dictionary with an explicit /Length but no /Filter is treated as
+        // uncompressed and read verbatim (no zlib decode).
+        let body = b"BT (HELLO) Tj ET";
+        let pdf = build_stream_object(2, "", body);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert_eq!(streams.len(), 1);
+        assert!(!streams[0].is_compressed);
+        assert_eq!(streams[0].compressed, body);
+
+        let texts =
+            extract_texts_from_stream(streams[0].compressed, streams[0].is_compressed).unwrap();
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].0, "HELLO");
+    }
+
+    #[test]
+    fn test_scanner_skips_non_flate_filter_stream() {
+        // A /DCTDecode (JPEG) image stream declares a /Filter we don't support.
+        // The scanner skips it entirely rather than mislabeling it uncompressed,
+        // so it is never decoded, scanned, or modified.
+        let body: &[u8] = &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]; // JPEG SOI marker bytes
+        let pdf = build_stream_object(3, " /Filter /DCTDecode /Subtype /Image", body);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert!(
+            streams.is_empty(),
+            "image stream should be skipped, got {}",
+            streams.len()
+        );
+    }
+
+    #[test]
+    fn test_scanner_iterates_multiple_mixed_streams() {
+        // Two consecutive stream objects (one FlateDecode, one plain) are both
+        // yielded, in order, with the correct compression classification.
+        let compressed = flate_compress(b"BT (A) Tj ET");
+        let mut pdf = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.3\n");
+        pdf.extend_from_slice(&build_stream_object(
+            1,
+            " /Filter [/FlateDecode]",
+            &compressed,
+        ));
+        pdf.extend_from_slice(&build_stream_object(2, "", b"BT (B) Tj ET"));
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert_eq!(streams.len(), 2);
+        assert!(streams[0].is_compressed);
+        assert!(!streams[1].is_compressed);
+    }
+
+    #[test]
+    fn test_scanner_skips_font_program_stream() {
+        // An embedded font program is identified by /Length1 (FontFile/FontFile2)
+        // and must never be scanned: its binary body carries no PDF text tokens.
+        let body: &[u8] = b"%!PS-AdobeFont binary font data";
+        let pdf = build_stream_object(3, " /Length1 12 /Length2 8 /Length3 0", body);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert!(
+            streams.is_empty(),
+            "font program should be skipped, got {}",
+            streams.len()
+        );
+    }
+
+    #[test]
+    fn test_scanner_skips_compressed_font_program_stream() {
+        // A Flate-compressed font program (/Length1 + /FlateDecode) must also be
+        // skipped: /Length1 is checked before the FlateDecode branch.
+        let compressed = flate_compress(b"binary font program bytes");
+        let pdf = build_stream_object(6, " /Length1 25 /Filter /FlateDecode", &compressed);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert!(
+            streams.is_empty(),
+            "compressed font program should be skipped, got {}",
+            streams.len()
+        );
+    }
+
+    #[test]
+    fn test_scanner_classifies_name_form_flate_as_compressed() {
+        // FlateDecode written as a name (/Filter /FlateDecode) rather than
+        // an array is recognized by the unified classifier and decoded.
+        let compressed = flate_compress(b"BT (SECRET) Tj ET");
+        let pdf = build_stream_object(4, " /Filter /FlateDecode", &compressed);
+
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert_eq!(streams.len(), 1);
+        assert!(streams[0].is_compressed);
+
+        let texts =
+            extract_texts_from_stream(streams[0].compressed, streams[0].is_compressed).unwrap();
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].0, "SECRET");
+    }
+
+    #[test]
+    fn test_scanner_discards_unclosed_text_object() {
+        // A `BT` never closed by `ET` (typical of non-content binary) must yield
+        // no tokens, even when it contains (...)Tj-like patterns.
+        let pdf = build_stream_object(5, "", b"BT (SHOULD NOT APPEAR) Tj (NOR THIS) Tj");
+        let streams: Vec<_> = stream_scanner(&pdf).collect();
+        assert_eq!(streams.len(), 1);
+        let texts =
+            extract_texts_from_stream(streams[0].compressed, streams[0].is_compressed).unwrap();
+        assert!(
+            texts.is_empty(),
+            "unclosed BT must yield no tokens, got {:?}",
+            texts
+        );
+    }
+
+    /// Returns path to `anonymizer_data/<name>` for offline integration tests.
+    /// Place plain PDF fixtures in that directory locally; they are git-ignored.
+    fn test_pdf_path(name: &str) -> std::path::PathBuf {
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let path = std::path::Path::new(manifest)
+            .join("anonymizer_data")
+            .join(name);
+        assert!(
+            path.exists(),
+            "Missing test fixture (place the PDF in anonymizer_data/): {}",
+            path.display()
+        );
+        path
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_end_to_end_cash_flow_preserved() {
+        let orig_path = test_pdf_path("sample_statement.pdf");
+
+        // Create anonymized output via the library replace function
+        let out_path = std::env::temp_dir().join("sample_statement_anonymized_test.pdf");
+        crate::anonymizer::replace::replace_pii_smart(&orig_path, &out_path)
+            .expect("anonymize failed");
+
+        let orig_bytes = read_pdf(&orig_path).expect("read orig");
+        let out_bytes = read_pdf(&out_path).expect("read out");
+
+        fn extract_section(pdf_bytes: &[u8]) -> Option<Vec<String>> {
+            for stream in stream_scanner(pdf_bytes) {
+                if let Ok(caps) = extract_texts_from_stream(stream.compressed, stream.is_compressed)
+                {
+                    if let Some(pos) = caps.iter().position(|(s, _st, _en)| {
+                        s.trim().eq_ignore_ascii_case("CASH FLOW ACTIVITY BY DATE")
+                    }) {
+                        let mut sec = Vec::new();
+                        for cap in caps.iter().skip(pos) {
+                            sec.push(cap.0.clone());
+                            if cap.0.to_uppercase().contains("NET CREDITS") {
+                                return Some(sec);
+                            }
+                        }
+                        return Some(sec);
+                    }
+                }
+            }
+            None
+        }
+
+        let orig_sec = extract_section(&orig_bytes).expect("orig sec");
+        let out_sec = extract_section(&out_bytes).expect("out sec");
+
+        assert!(orig_sec
+            .iter()
+            .any(|s| s.trim().eq_ignore_ascii_case("CASH FLOW ACTIVITY BY DATE")));
+        assert!(orig_sec
+            .iter()
+            .any(|s| s.to_uppercase().contains("NET CREDITS")));
+        assert_eq!(
+            orig_sec, out_sec,
+            "CASH FLOW section changed after anonymize"
+        );
+
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_extract_integration_investments() {
+        // Integration-style test: open the sample PDF from the repo and
+        // assert that our extractor finds the visible "INVESTMENTS" string
+        // in at least one stream. This makes the regression explicit.
+        let pdf_path = test_pdf_path("sample_statement.pdf");
+        let pdf_bytes = match read_pdf(&pdf_path) {
+            Ok(b) => b,
+            Err(e) => panic!("Failed to read sample PDF: {}", e),
+        };
+
+        let mut found = false;
+        for stream in stream_scanner(&pdf_bytes) {
+            let compressed = stream.compressed;
+            if let Ok(texts) = extract_texts_from_stream(compressed, stream.is_compressed) {
+                for (s, _st, _en) in texts.iter() {
+                    if s.to_uppercase().contains("INVESTMENTS") {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if found {
+                break;
+            }
+        }
+
+        assert!(
+            found,
+            "Extractor did not find 'INVESTMENTS' in sample PDF streams"
+        );
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_indexed_list_output_consistency() {
+        use std::collections::HashMap;
+
+        let pdf_path = test_pdf_path("sample_statement.pdf");
+        let pdf_bytes = match read_pdf(&pdf_path) {
+            Ok(b) => b,
+            Err(e) => panic!("Failed to read sample PDF: {}", e),
+        };
+
+        // preserved tokens that should remain literal in the output
+        let preserved = ["CLIENT STATEMENT", "For the Period"];
+
+        let mut global_map: HashMap<String, usize> = HashMap::new();
+        let mut next_idx: usize = 0;
+
+        // First pass: build global mapping of non-preserved strings to indices
+        for stream in stream_scanner(&pdf_bytes) {
+            let caps = match extract_texts_from_stream(stream.compressed, stream.is_compressed) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            for (s, _st, _en) in caps {
+                let key = s.clone();
+                if preserved.iter().any(|p| key.starts_with(p)) {
+                    continue; // preserve
+                }
+                if !global_map.contains_key(&key) {
+                    global_map.insert(key.clone(), next_idx);
+                    next_idx += 1;
+                }
+            }
+        }
+
+        // We expect the INVESTMENTS phrase to be present in the map and thus indexed
+        let investments_key = global_map
+            .keys()
+            .find(|k| k.to_uppercase().contains("INVESTMENTS"));
+        assert!(
+            investments_key.is_some(),
+            "INVESTMENTS was not indexed in the global map"
+        );
+
+        // Second pass: ensure consistent replacement (same string -> same index)
+        for stream in stream_scanner(&pdf_bytes) {
+            let caps = match extract_texts_from_stream(stream.compressed, stream.is_compressed) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            for (s, _st, _en) in caps {
+                let key = s.clone();
+                if preserved.iter().any(|p| key.starts_with(p)) {
+                    // preserved tokens must remain textual
+                    assert!(preserved.iter().any(|p| key.starts_with(p)));
+                } else {
+                    let idx = global_map.get(&key).expect("Missing mapping for token");
+                    // index must be stable and within range
+                    assert!(*idx < next_idx);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_anonymized_output_matches_expected() {
+        // Run the anonymizer on the input PDF and compare extracted text
+        // tokens from the result with those from the expected anonymized PDF.
+        let input_path = test_pdf_path("sample_statement.pdf");
+        let expected_path = test_pdf_path("sample_statement_anonymized.pdf");
+
+        // Run anonymizer
+        let actual_path = std::env::temp_dir().join("test_anonymized_output_cmp.pdf");
+        crate::anonymizer::replace::replace_pii_smart(&input_path, &actual_path)
+            .expect("anonymize failed");
+
+        // Extract all text tokens from both PDFs
+        fn all_tokens(pdf_path: &std::path::Path) -> Vec<Vec<String>> {
+            let data = read_pdf(pdf_path).expect("read pdf");
+            let mut result = Vec::new();
+            for stream in stream_scanner(&data) {
+                if let Ok(caps) = extract_texts_from_stream(stream.compressed, stream.is_compressed)
+                {
+                    let texts: Vec<String> = caps
+                        .into_iter()
+                        .map(|(s, _, _)| s)
+                        // Filter out non-printable binary junk to allow stable comparison
+                        .filter(|s| {
+                            s.chars()
+                                .all(|c| c.is_ascii_graphic() || c.is_ascii_whitespace())
+                        })
+                        .collect();
+                    if !texts.is_empty() {
+                        result.push(texts);
+                    }
+                }
+            }
+            result
+        }
+
+        let expected_tokens = all_tokens(&expected_path);
+        let actual_tokens = all_tokens(&actual_path);
+
+        // We compare as many streams as we have in the older baseline
+        for (i, (exp, act)) in expected_tokens.iter().zip(actual_tokens.iter()).enumerate() {
+            assert_eq!(
+                exp, act,
+                "Stream {} tokens differ.\nExpected: {:?}\nActual:   {:?}",
+                i, exp, act
+            );
+        }
+
+        // Ensure we didn't lose any data (new engine should find AT LEAST as many as old)
+        assert!(
+            actual_tokens.len() >= expected_tokens.len(),
+            "Regression: new engine found fewer text streams ({}) than the old one ({})",
+            actual_tokens.len(),
+            expected_tokens.len()
+        );
+
+        let _ = std::fs::remove_file(&actual_path);
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_pdf_structure_skeleton_integrity() {
+        // Ultimate integrity test: verify that outside of the text literals (...),
+        // every single byte of the PDF stream (operators, coordinates, etc.)
+        // remains exactly the same.
+        let input_path = test_pdf_path("sample_statement.pdf");
+        let actual_path = std::env::temp_dir().join("integrity_skeleton_test.pdf");
+        crate::anonymizer::replace::replace_pii_smart(&input_path, &actual_path)
+            .expect("anonymize failed");
+
+        let input_data = read_pdf(&input_path).expect("read input");
+        let actual_data = read_pdf(&actual_path).expect("read actual");
+
+        fn get_stream_skeleton(stream_data: &[u8]) -> Vec<u8> {
+            let mut decoder = ZlibDecoder::new(stream_data);
+            let mut decompressed = Vec::new();
+            let _ = decoder.read_to_end(&mut decompressed);
+
+            let mut skeleton = Vec::with_capacity(decompressed.len());
+            let mut i = 0;
+            while i < decompressed.len() {
+                if decompressed[i] == b'(' {
+                    // Skip everything inside literal until matching )
+                    skeleton.push(b'(');
+                    skeleton.push(b'*'); // Placeholder for any text
+                    skeleton.push(b')');
+
+                    let mut depth = 1;
+                    i += 1;
+                    while i < decompressed.len() && depth > 0 {
+                        if decompressed[i] == b'\\' && i + 1 < decompressed.len() {
+                            i += 2;
+                            continue;
+                        }
+                        if decompressed[i] == b'(' {
+                            depth += 1;
+                        } else if decompressed[i] == b')' {
+                            depth -= 1;
+                        }
+                        i += 1;
+                    }
+                } else {
+                    skeleton.push(decompressed[i]);
+                    i += 1;
+                }
+            }
+            skeleton
+        }
+
+        let input_streams: Vec<_> = stream_scanner(&input_data).collect();
+        let actual_streams: Vec<_> = stream_scanner(&actual_data).collect();
+
+        assert_eq!(
+            input_streams.len(),
+            actual_streams.len(),
+            "Stream count changed!"
+        );
+
+        for (i, (in_s, act_s)) in input_streams.iter().zip(actual_streams.iter()).enumerate() {
+            let skel_in = get_stream_skeleton(in_s.compressed);
+            let skel_act = get_stream_skeleton(act_s.compressed);
+
+            assert_eq!(
+                skel_in, skel_act,
+                "Integrity violation in stream {}: non-textual bytes were modified!",
+                i
+            );
+        }
+
+        let _ = std::fs::remove_file(&actual_path);
+    }
+
+    #[test]
+    #[ignore = "requires local PDF fixtures in anonymizer_data/"]
+    fn test_font_program_streams_not_modified() {
+        // Embedded font programs (/Length1) must be byte-for-byte identical after
+        // anonymization. Guards against the scanner ever treating coincidental
+        // byte patterns in binary font data as text tokens.
+        let input_path = test_pdf_path("sample_statement.pdf");
+        let out_path = std::env::temp_dir().join("font_integrity_test.pdf");
+        crate::anonymizer::replace::replace_pii_smart(&input_path, &out_path)
+            .expect("anonymize failed");
+
+        let inp = read_pdf(&input_path).expect("read input");
+        let out = read_pdf(&out_path).expect("read output");
+        assert_eq!(inp.len(), out.len(), "file length changed");
+
+        let re = regex::bytes::Regex::new(
+            r"(?s)\d+\s+\d+\s+obj\s*<<[^>]*?/Length\s+(\d+)[^>]*?/Length1\s+\d+[^>]*?>>\s*stream\r?\n",
+        )
+        .unwrap();
+        let mut checked = 0;
+        for caps in re.captures_iter(&inp) {
+            let whole = caps.get(0).unwrap();
+            let len: usize = std::str::from_utf8(caps.get(1).unwrap().as_bytes())
+                .unwrap()
+                .parse()
+                .unwrap();
+            let start = whole.end();
+            assert_eq!(
+                &inp[start..start + len],
+                &out[start..start + len],
+                "embedded font program bytes changed after anonymize"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "expected at least one /Length1 font program in fixture"
+        );
+        let _ = std::fs::remove_file(&out_path);
+    }
+}

--- a/src/anonymizer/replace.rs
+++ b/src/anonymizer/replace.rs
@@ -1,0 +1,436 @@
+// SPDX-FileCopyrightText: 2025 RustInFinance
+// SPDX-License-Identifier: BSD-3-Clause
+
+//! String replacement module for anonymizer.
+//!
+//! This module applies specified text replacements to all FlateDecode streams in a PDF.
+//! For each stream, the module:
+//! 1. Decompresses the stream data
+//! 2. Applies all specified string replacements
+//! 3. Recompresses the modified text to the exact original size (with padding if necessary)
+//! 4. Writes the modified PDF to the output file
+//!
+//! The in-place replacement strategy avoids rebuilding the PDF's XREF table,
+//! ensuring the output PDF remains valid without full PDF structure parsing.
+
+use super::pdf::{extract_texts_from_decompressed, read_pdf, stream_scanner};
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use log::{debug, info, warn};
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+/// Replace PII using smart anonymization.
+///
+/// 1. Preserve strings containing 'CLIENT STATEMENT' or 'For the Period'
+/// 2. Replace all other strings with stable numeric tokens (0, 1, 2, ...)
+/// 3. When 'CASH FLOW ACTIVITY BY DATE' is encountered, preserve all strings until
+///    'NET CREDITS/(DEBITS)' is found (inclusive)
+///
+/// # Arguments
+/// * `input_path` - Path to the input PDF file
+/// * `output_path` - Path where the anonymized PDF will be written
+///
+/// # Returns
+/// * `Ok(())` on success
+/// * `Err` if PDF cannot be read or processed
+pub fn replace_pii_smart(
+    input_path: &Path,
+    output_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    info!("Smart anonymization mode");
+    info!("Loading: {}", input_path.display());
+
+    let pdf_data = read_pdf(input_path)?;
+    debug!("PDF Size: {} bytes", pdf_data.len());
+
+    let mut output_data = pdf_data.clone();
+    let mut streams_modified = 0;
+    let mut streams_total = 0;
+    let mut streams_skipped = 0;
+    let mut letter_counter = 0;
+    let mut in_cash_flow_section = false;
+
+    for stream in stream_scanner(&pdf_data) {
+        if !stream.valid_end_marker {
+            warn!(
+                "Skipping stream due to end-marker mismatch for object at {}",
+                stream.object_start
+            );
+            streams_skipped += 1;
+            continue;
+        }
+        streams_total += 1;
+
+        let stream_data = stream.compressed;
+        let data_start = stream.data_start;
+        let is_compressed = stream.is_compressed;
+
+        debug!(
+            "═══ Stream #{} (compressed={}) ═══",
+            streams_total, is_compressed
+        );
+        debug!(
+            "Position: {}-{} ({} B)",
+            data_start,
+            data_start + stream_data.len(),
+            stream_data.len()
+        );
+
+        match process_stream_smart(
+            stream_data,
+            is_compressed,
+            &mut letter_counter,
+            &mut in_cash_flow_section,
+        ) {
+            Ok((new_data, modified)) => {
+                // Check size and warn if too large
+                if new_data.len() > stream_data.len() {
+                    warn!(
+                        "Cannot fit modified data: {} > {} bytes",
+                        new_data.len(),
+                        stream_data.len()
+                    );
+                    warn!("Skipping modifications for this stream");
+                    streams_skipped += 1;
+                    continue;
+                }
+
+                // Count only streams whose modifications are actually written out.
+                if modified {
+                    streams_modified += 1;
+                }
+
+                // Write new data
+                for (idx, &byte) in new_data.iter().enumerate() {
+                    output_data[data_start + idx] = byte;
+                }
+
+                // Pad remaining space with NULL bytes to maintain the exact original stream
+                // length. Preserving the byte length keeps every subsequent object offset (and
+                // therefore the XREF table) valid, so we never need to rebuild it. This applies
+                // to both compressed and uncompressed streams; the trailing padding sits after
+                // the logical end of the stream content and is ignored by PDF readers.
+                let padding_len = stream_data.len() - new_data.len();
+                for idx in new_data.len()..stream_data.len() {
+                    output_data[data_start + idx] = 0x00;
+                }
+
+                if padding_len > 0 {
+                    debug!("Applied padding of {} bytes to stream", padding_len);
+                }
+
+                debug!("Data size: {} → {} B", stream_data.len(), new_data.len());
+            }
+            Err(e) => {
+                warn!("Failed to process stream: {}", e);
+                streams_skipped += 1;
+            }
+        }
+    }
+
+    // Warn loudly (output is still produced): a cash-flow section that opened but
+    // never closed means every token after it was preserved and may still contain PII.
+    if in_cash_flow_section {
+        warn!(
+            "CASH FLOW section opened but its closing marker was never found; \
+             tokens after it were preserved and may not be anonymized"
+        );
+    }
+
+    info!("Saving: {}", output_path.display());
+    File::create(output_path)?.write_all(&output_data)?;
+
+    info!("DONE!");
+    info!(
+        "Streams: total={} modified={}",
+        streams_total, streams_modified
+    );
+    if streams_skipped > 0 {
+        warn!(
+            "Skipped {} stream(s); their bytes were left unmodified and may still contain PII",
+            streams_skipped
+        );
+    }
+    info!("File: {}", output_path.display());
+
+    Ok(())
+}
+
+/// Check if a text should be preserved based on content rules.
+fn should_preserve_text(text: &str) -> bool {
+    text.contains("CLIENT STATEMENT") || text.contains("For the Period")
+}
+
+/// Process a single stream with smart anonymization.
+/// Returns (output_data, was_modified).
+/// For compressed streams, returns compressed data. For uncompressed, returns raw data.
+fn process_stream_smart(
+    stream_data: &[u8],
+    is_compressed: bool,
+    letter_counter: &mut usize,
+    in_cash_flow_section: &mut bool,
+) -> Result<(Vec<u8>, bool), Box<dyn std::error::Error>> {
+    use flate2::read::ZlibDecoder;
+    use std::io::Read;
+
+    let original_len = stream_data.len();
+
+    info!(
+        "Processing stream len={} compressed={}",
+        original_len, is_compressed
+    );
+
+    // Decompress if needed
+    let mut decompressed = Vec::new();
+    if is_compressed {
+        let mut decoder = ZlibDecoder::new(stream_data);
+        decoder.read_to_end(&mut decompressed)?;
+    } else {
+        decompressed = stream_data.to_vec();
+    }
+
+    debug!("Decompressed: {} B", decompressed.len());
+
+    // Extract texts along with their byte positions in the decompressed stream.
+    // Reuse the buffer we just decompressed above to avoid a second decompression.
+    let texts = extract_texts_from_decompressed(&decompressed);
+
+    // Build replacement list based on rules
+    let mut replacements: Vec<(usize, usize, Vec<u8>)> = Vec::new();
+    for (text, start, end) in texts.iter() {
+        let current_token_index = *letter_counter;
+        *letter_counter += 1;
+
+        // Log token detection for debugging
+        debug!(
+            "Token[{}] '{}' at {}..{} (in_cash_flow={})",
+            current_token_index, text, start, end, in_cash_flow_section
+        );
+
+        // Preserve start/end markers of the CASH FLOW section explicitly.
+        if text.contains("CASH FLOW ACTIVITY BY DATE") {
+            *in_cash_flow_section = true;
+            debug!("Entering CASH FLOW section");
+            debug!("Preserving token[{}] '{}'", current_token_index, text);
+            continue;
+        }
+
+        // Preserve the closing marker and then exit the cash flow section.
+        if text.contains("NET CREDITS/(DEBITS)") {
+            debug!("Preserving token[{}] '{}'", current_token_index, text);
+            *in_cash_flow_section = false;
+            debug!("Exiting CASH FLOW section");
+            continue;
+        }
+
+        // Check if we should preserve this text by general rules
+        if *in_cash_flow_section || should_preserve_text(text) {
+            debug!("Preserving token[{}] '{}'", current_token_index, text);
+            continue;
+        } else {
+            // Replace entire token with its global index number
+            let replacement_str = current_token_index.to_string();
+
+            // PDF string literals are stored escaped in the decompressed stream,
+            // but our replacement uses only ASCII digits, so converting
+            // to bytes is safe here.
+            let replacement_bytes = replacement_str.as_bytes().to_vec();
+            debug!(
+                "Scheduling replacement for token[{}] '{}' -> '{}' ({} bytes)",
+                current_token_index,
+                text,
+                replacement_str,
+                replacement_bytes.len()
+            );
+            replacements.push((*start, *end, replacement_bytes));
+        }
+    }
+
+    // Apply replacements to decompressed data. Perform in reverse order of
+    // positions so earlier replacements do not affect subsequent indices.
+    let mut modified_data = decompressed.clone();
+    let mut was_modified = false;
+
+    if !replacements.is_empty() {
+        // Sort by start descending
+        replacements.sort_by_key(|t| std::cmp::Reverse(t.0));
+        for (start, end, repl_bytes) in replacements.iter() {
+            let s = *start;
+            let e = *end;
+            // Build new buffer with replacement applied
+            let mut new_buf = Vec::with_capacity(modified_data.len() - (e - s) + repl_bytes.len());
+            new_buf.extend_from_slice(&modified_data[..s]);
+            new_buf.extend_from_slice(repl_bytes);
+            new_buf.extend_from_slice(&modified_data[e..]);
+            modified_data = new_buf;
+            was_modified = true;
+            debug!(
+                "Applied replacement at {}..{} ({} B)",
+                s,
+                e,
+                repl_bytes.len()
+            );
+        }
+    }
+
+    // Recompress to fit original size (only for compressed streams)
+    if was_modified {
+        if is_compressed {
+            if let Some((compressed, level)) =
+                find_fitting_compression(&modified_data, original_len)
+            {
+                debug!(
+                    "Compressed with level {} ({} B <= {} B)",
+                    level,
+                    compressed.len(),
+                    original_len
+                );
+                return Ok((compressed, true));
+            } else {
+                warn!(
+                    "Cannot fit modified data into original size ({}B); keeping original",
+                    original_len
+                );
+                return Ok((stream_data.to_vec(), false));
+            }
+        } else {
+            // Uncompressed stream - return modified data directly
+            return Ok((modified_data, true));
+        }
+    }
+
+    Ok((stream_data.to_vec(), false))
+}
+
+/// Try progressive zlib compression levels (0..=9) returning the first compressed form whose length is <= `max_size`.
+fn find_fitting_compression(data: &[u8], max_size: usize) -> Option<(Vec<u8>, u32)> {
+    for level in 0..=9 {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::new(level));
+        if encoder.write_all(data).is_err() {
+            continue;
+        }
+        let compressed = encoder.finish().ok()?;
+        if compressed.len() <= max_size {
+            return Some((compressed, level));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::read::ZlibDecoder;
+    use std::io::Read;
+
+    /// Helper: run `process_stream_smart` on uncompressed content with fresh state.
+    fn process_uncompressed(content: &[u8]) -> (Vec<u8>, bool, usize) {
+        let mut counter = 0usize;
+        let mut in_cash_flow = false;
+        let (out, modified) =
+            process_stream_smart(content, false, &mut counter, &mut in_cash_flow).unwrap();
+        (out, modified, counter)
+    }
+
+    #[test]
+    fn test_replaces_pii_and_preserves_marker_uncompressed() {
+        // "JAN KOWALSKI" is PII -> replaced with its token index (0).
+        // "CLIENT STATEMENT" is a preserved marker -> kept verbatim.
+        let content = b"BT (JAN KOWALSKI) Tj (CLIENT STATEMENT) Tj ET";
+        let (out, modified, counter) = process_uncompressed(content);
+
+        assert!(modified, "stream with PII should be reported as modified");
+        assert_eq!(out, b"BT (0) Tj (CLIENT STATEMENT) Tj ET");
+        // Two tokens were scanned, so the global counter advanced by two.
+        assert_eq!(counter, 2);
+    }
+
+    #[test]
+    fn test_preserves_cash_flow_section_then_resumes_replacement() {
+        // Everything from "CASH FLOW ACTIVITY BY DATE" to "NET CREDITS/(DEBITS)"
+        // (inclusive) must be preserved; tokens after the section are replaced again.
+        let content =
+            b"BT (CASH FLOW ACTIVITY BY DATE) Tj (9/1/25) Tj (100.00) Tj (NET CREDITS/(DEBITS)) Tj (SECRET) Tj ET";
+        let (out, modified, counter) = process_uncompressed(content);
+
+        assert!(modified);
+        let out_str = String::from_utf8(out).unwrap();
+        // In-section tokens are untouched.
+        assert!(out_str.contains("(CASH FLOW ACTIVITY BY DATE)"));
+        assert!(out_str.contains("(9/1/25)"));
+        assert!(out_str.contains("(100.00)"));
+        assert!(out_str.contains("(NET CREDITS/(DEBITS))"));
+        // The token after the section ("SECRET") is the 5th token (index 4).
+        assert!(out_str.contains("(4) Tj ET"));
+        assert!(!out_str.contains("SECRET"));
+        assert_eq!(counter, 5);
+    }
+
+    #[test]
+    fn test_no_change_when_all_tokens_preserved_uncompressed() {
+        let content = b"BT (CLIENT STATEMENT) Tj (For the Period) Tj ET";
+        let (out, modified, counter) = process_uncompressed(content);
+
+        assert!(!modified, "fully preserved stream must not be modified");
+        assert_eq!(out, content, "unmodified stream must be returned verbatim");
+        assert_eq!(counter, 2);
+    }
+
+    #[test]
+    fn test_compressed_stream_roundtrip_replacement() {
+        // A real FlateDecode stream: compress a content stream, run it through the
+        // compressed path, and verify the replacement survives a decompress round-trip.
+        // The original is stored uncompressed (`Compression::none()`) so that the
+        // (shorter) modified stream is guaranteed to fit the original size without
+        // depending on exact compressor byte counts.
+        let content = b"BT (SECRET) Tj (CLIENT STATEMENT) Tj ET";
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::none());
+        encoder.write_all(content).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let original_len = compressed.len();
+
+        let mut counter = 0usize;
+        let mut in_cash_flow = false;
+        let (out, modified) =
+            process_stream_smart(&compressed, true, &mut counter, &mut in_cash_flow).unwrap();
+
+        assert!(modified);
+        // Output must still fit the original compressed size (XREF-preserving invariant).
+        assert!(
+            out.len() <= original_len,
+            "recompressed stream ({}) must fit original size ({})",
+            out.len(),
+            original_len
+        );
+
+        // Decompress and verify: "SECRET" -> token index 0, marker preserved.
+        let mut decoder = ZlibDecoder::new(&out[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).unwrap();
+        assert_eq!(decompressed, b"BT (0) Tj (CLIENT STATEMENT) Tj ET");
+        assert_eq!(counter, 2);
+    }
+
+    #[test]
+    fn test_cash_flow_section_stays_open_without_closing_marker() {
+        // Opening marker with no closing "NET CREDITS/(DEBITS)": the section stays
+        // open, so later tokens are preserved (not anonymized). This is the state
+        // that replace_pii_smart surfaces via a warning.
+        let content = b"BT (CASH FLOW ACTIVITY BY DATE) Tj (STILL SECRET) Tj ET";
+        let mut counter = 0usize;
+        let mut in_cash_flow = false;
+        let (out, _modified) =
+            process_stream_smart(content, false, &mut counter, &mut in_cash_flow).unwrap();
+
+        assert!(
+            in_cash_flow,
+            "section must remain open when the closing marker is absent"
+        );
+        // The post-marker token was preserved verbatim (the potential leak the warning flags).
+        let out_str = String::from_utf8(out).unwrap();
+        assert!(out_str.contains("(STILL SECRET)"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ mod pdfparser;
 mod transactions;
 mod xlsxparser;
 
+// Public because the `etradeAnonymizer` binary references it as `etradeTaxReturnHelper::anonymizer::...`.
+pub mod anonymizer;
+
 type ReqwestClient = reqwest::blocking::Client;
 
 pub use logging::ResultExt;


### PR DESCRIPTION
Introduces `etradeAnonymizer` — a Rust binary and `anonymizer` module for anonymizing E*TRADE / Morgan Stanley PDF statements while preserving data needed for tax calculations.

## Subcommands
- `list <input.pdf>` — lists all text tokens from FlateDecode/uncompressed streams (debugging/inspection).
- `anonymize <input.pdf> [output.pdf]` — replaces PII with stable numeric tokens; output defaults to `anonymous_<input>.pdf`.

## How it works
- Operates directly on PDF streams (FlateDecode and uncompressed with an explicit `/Length`, PDF 1.3).
- Preserves calculation-relevant text: strings containing `CLIENT STATEMENT` / `For the Period`, and everything between `CASH FLOW ACTIVITY BY DATE` and `NET CREDITS/(DEBITS)` (inclusive).
- In-place replacement that keeps the exact original stream size (recompression + null-byte padding), so the PDF XREF table stays valid without full re-parsing.

## Module layout
- `list.rs`, `replace.rs` (engine: `replace_pii_smart`), `path.rs`, `pdf.rs`. No separate `detect` module/mode.

## Testing
- Unit tests run in CI (PDF token scanning, escape/unescape, output path handling).
- 5 integration tests are marked `#[ignore]` — they require local plain PDF fixtures in `anonymizer_data/` (git-ignored) and do not run in CI.

## Notes
- No `openssl` dependency, no bundled encrypted fixtures, no `ANONYMIZER_TEST_KEY` in CI.
- Not a guarantee of complete PII removal — output should be reviewed manually before sharing.
